### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -5,30 +5,30 @@
 #==============================================================================
 # Datatypes (KEYWORD1)
 #==============================================================================
-SnesController  KEYWORD1
+SnesController	KEYWORD1
 
 #==============================================================================
 # Methods and Functions (KEYWORD2)
 #==============================================================================
-poll            KEYWORD2
-getRawState     KEYWORD2
-isPressed       KEYWORD2
-wasPressed      KEYWORD2
-wasReleased     KEYWORD2
-getHeldTime     KEYWORD2
+poll	KEYWORD2
+getRawState	KEYWORD2
+isPressed	KEYWORD2
+wasPressed	KEYWORD2
+wasReleased	KEYWORD2
+getHeldTime	KEYWORD2
 
 #==============================================================================
 # Constants (LITERAL1)
 #==============================================================================
-START           LITERAL1
-SELECT          LITERAL1
-UP              LITERAL1
-DOWN            LITERAL1
-LEFT            LITERAL1
-RIGHT           LITERAL1
-A               LITERAL1
-B               LITERAL1
-X               LITERAL1
-Y               LITERAL1
-L               LITERAL1
-R               LITERAL1
+START	LITERAL1
+SELECT	LITERAL1
+UP	LITERAL1
+DOWN	LITERAL1
+LEFT	LITERAL1
+RIGHT	LITERAL1
+A	LITERAL1
+B	LITERAL1
+X	LITERAL1
+Y	LITERAL1
+L	LITERAL1
+R	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords